### PR TITLE
[services] Fix building for devices using QCOM_DIRECTTRACK.

### DIFF
--- a/services/audioflinger_5_1_0.h
+++ b/services/audioflinger_5_1_0.h
@@ -72,6 +72,23 @@ public:
         return 0;
     }
 
+#ifdef QCOM_DIRECTTRACK
+    virtual sp<IDirectTrack> createDirectTrack(
+                                pid_t pid,
+                                uint32_t sampleRate,
+                                audio_channel_mask_t channelMask,
+                                audio_io_handle_t output,
+                                int *sessionId,
+                                IDirectTrackClient* client,
+                                audio_stream_type_t streamType,
+                                status_t *status) {
+        return 0;
+    }
+
+    virtual void deleteEffectSession() {
+    }
+#endif
+
     virtual sp<IAudioRecord> openRecord(
                                 audio_io_handle_t input,
                                 uint32_t sampleRate,


### PR DESCRIPTION
This additional function is needed on some device, currently at least Sony Xperia SP and Oppo Find 5. This should not cause any problems on other devices because of the #ifdef. Definition of the function can be found here https://github.com/CyanogenMod/android_frameworks_av/blob/stable/cm-12.1-YOG7D/services/audioflinger/AudioFlinger.h#L144
