### PR TITLE
Fix QCOM_DIRECTTRACK support and add support for cm-11.0 and cm-13.0 based ports.

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -30,6 +30,14 @@ endif
 include $(CLEAR_VARS)
 LOCAL_SRC_FILES := audioflingerglue.cpp IPrivateAfGlue.cpp IPrivateAfGlueHandler.cpp
 
+ifeq ($(strip $(ANDROID_MAJOR)), 4)
+LOCAL_SHARED_LIBRARIES := libc \
+                          libdl \
+                          libutils \
+                          libcutils \
+                          libbinder \
+                          libmedia
+else
 LOCAL_SHARED_LIBRARIES := libc \
                           libdl \
                           libutils \
@@ -37,6 +45,7 @@ LOCAL_SHARED_LIBRARIES := libc \
                           libbinder \
                           libmedia \
                           libserviceutility
+endif
 LOCAL_CPPFLAGS=-DANDROID_MAJOR=$(ANDROID_MAJOR) -DANDROID_MINOR=$(ANDROID_MINOR) -DANDROID_MICRO=$(ANDROID_MICRO)
 LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE := libaudioflingerglue

--- a/IPrivateAfGlue.cpp
+++ b/IPrivateAfGlue.cpp
@@ -78,7 +78,11 @@ public:
             data.writeInt32(0);
         else
             data.writeInt32(1);
+#if ANDROID_MAJOR == 6
+        data.writeStrongBinder(IInterface::asBinder(handler));
+#else
         data.writeStrongBinder(handler->asBinder());
+#endif
         remote()->transact(REGISTER_HANDLER, data, &reply);
     }
 };

--- a/miniaf.cpp
+++ b/miniaf.cpp
@@ -30,6 +30,8 @@
 #include "services/audioflinger_4_4_0.h"
 #elif ANDROID_MAJOR == 5 && ANDROID_MINOR == 1
 #include "services/audioflinger_5_1_0.h"
+#elif ANDROID_MAJOR == 6 && ANDROID_MINOR == 0
+#include "services/audioflinger_6_0_0.h"
 #else
 #error Unsupported Android version.
 #endif

--- a/miniaf.cpp
+++ b/miniaf.cpp
@@ -26,7 +26,9 @@
 #include <binder/MemoryHeapBase.h>
 #include "PrivateAfGlue.h"
 
-#if ANDROID_MAJOR == 5 && ANDROID_MINOR == 1
+#if ANDROID_MAJOR == 4 && ANDROID_MINOR == 4
+#include "services/audioflinger_4_4_0.h"
+#elif ANDROID_MAJOR == 5 && ANDROID_MINOR == 1
 #include "services/audioflinger_5_1_0.h"
 #else
 #error Unsupported Android version.

--- a/services/audioflinger_4_4_0.h
+++ b/services/audioflinger_4_4_0.h
@@ -1,0 +1,299 @@
+/*
+ * Copyright (C) 2015 Jolla Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Authored by: Juho Hämäläinen <juho.hamalainen@jollamobile.com>
+ */
+
+#include <media/IAudioFlingerClient.h>
+#include "IPrivateAfGlue.h"
+#include "common.h"
+
+using namespace android;
+
+class MiniAudioFlinger : public BinderService<MiniAudioFlinger>,
+                         public BnAudioFlinger,
+                         public IBinder::DeathRecipient
+{
+    friend class BinderService<MiniAudioFlinger>;
+
+    static sp<IPrivateAfGlue> gPrivateAfGlue;
+
+public:
+    static char const *getServiceName() {
+        return "media.audio_flinger";
+    }
+
+    MiniAudioFlinger() : BnAudioFlinger()
+    {
+        sp<IPrivateAfGlue> af;
+        sp<IServiceManager> sm = defaultServiceManager();
+        sp<IBinder> binder;
+
+        binder = sm->getService(String16(DROID_AFGLUE_SERVICE_NAME));
+        if (binder == 0) {
+            ALOGE("Couldn't find %s service", DROID_AFGLUE_SERVICE_NAME);
+        }
+        af = interface_cast<IPrivateAfGlue>(binder);
+
+        gPrivateAfGlue = af;
+    }
+
+    ~MiniAudioFlinger() {}
+
+    void binderDied(const wp<IBinder>&) {
+        // Nothing
+    }
+
+    virtual sp<IAudioTrack> createTrack(
+                                audio_stream_type_t streamType,
+                                uint32_t sampleRate,
+                                audio_format_t format,
+                                audio_channel_mask_t channelMask,
+                                size_t frameCount,
+                                track_flags_t *flags,
+                                const sp<IMemory>& sharedBuffer,
+                                audio_io_handle_t output,
+                                pid_t tid,  // -1 means unused, otherwise must be valid non-0
+                                int *sessionId,
+                                // input: ignored
+                                // output: server's description of IAudioTrack for display in logs.
+                                // Don't attempt to parse, as the format could change.
+                                String8& name,
+                                int clientUid,
+                                status_t *status) {
+        return 0;
+    }
+
+
+#ifdef QCOM_DIRECTTRACK
+    /* create a direct audio track and registers it with AudioFlinger.
+     * return null if the track cannot be created.
+     */
+    virtual sp<IDirectTrack> createDirectTrack(
+                                pid_t pid,
+                                uint32_t sampleRate,
+                                audio_channel_mask_t channelMask,
+                                audio_io_handle_t output,
+                                int *sessionId,
+                                IDirectTrackClient* client,
+                                audio_stream_type_t streamType,
+                                status_t *status) {
+        return 0;
+    }
+#endif
+
+    virtual sp<IAudioRecord> openRecord(
+                                audio_io_handle_t input,
+                                uint32_t sampleRate,
+                                audio_format_t format,
+                                audio_channel_mask_t channelMask,
+                                size_t frameCount,
+                                track_flags_t *flags,
+                                pid_t tid,  // -1 means unused, otherwise must be valid non-0
+                                int *sessionId,
+                                status_t *status) {
+        return 0;
+    }
+
+    virtual uint32_t sampleRate(audio_io_handle_t output) const {
+        return 0;
+    }
+
+    virtual audio_format_t format(audio_io_handle_t output) const {
+        return AUDIO_FORMAT_DEFAULT;
+    }
+
+    virtual size_t frameCount(audio_io_handle_t output) const {
+        return 0;
+    }
+
+    virtual uint32_t latency(audio_io_handle_t output) const {
+        return 0;
+    }
+
+    virtual status_t setMasterVolume(float value) {
+        return NO_ERROR;
+    }
+    virtual status_t setMasterMute(bool muted) {
+        return NO_ERROR;
+    }
+
+    virtual float masterVolume() const {
+        return 0;
+    }
+
+    virtual bool masterMute() const {
+        return false;
+    }
+
+    virtual     status_t    setStreamVolume(audio_stream_type_t stream, float value,
+                                    audio_io_handle_t output) {
+        return NO_ERROR;
+    }
+
+    virtual     status_t    setStreamMute(audio_stream_type_t stream, bool muted) {
+        return NO_ERROR;
+    }
+
+    virtual     float       streamVolume(audio_stream_type_t stream,
+                                    audio_io_handle_t output) const {
+        return 0;
+    }
+    virtual     bool        streamMute(audio_stream_type_t stream) const {
+        return false;
+    }
+
+    virtual     status_t    setMode(audio_mode_t mode) {
+        return NO_ERROR;
+    }
+
+    virtual     status_t    setMicMute(bool state) {
+        return NO_ERROR;
+    }
+
+    virtual     bool        getMicMute() const {
+        return false;
+    }
+
+    virtual     status_t    setParameters(audio_io_handle_t ioHandle,
+                                    const String8& keyValuePairs) {
+        return gPrivateAfGlue->setParameters(ioHandle, keyValuePairs);
+    }
+
+    virtual     String8     getParameters(audio_io_handle_t ioHandle, const String8& keys) const {
+        return gPrivateAfGlue->getParameters(ioHandle, keys);
+    }
+
+    virtual void registerClient(const sp<IAudioFlingerClient>& client) {}
+
+    virtual size_t getInputBufferSize(uint32_t sampleRate, audio_format_t format,
+            audio_channel_mask_t channelMask) const {
+        return 0;
+    }
+
+    virtual status_t openOutput(audio_module_handle_t module,
+                                         audio_devices_t *pDevices,
+                                         uint32_t *pSamplingRate,
+                                         audio_format_t *pFormat,
+                                         audio_channel_mask_t *pChannelMask,
+                                         uint32_t *pLatencyMs,
+                                         audio_output_flags_t flags,
+                                         const audio_offload_info_t *offloadInfo = NULL) {
+        return NO_ERROR;
+    }
+
+    virtual audio_io_handle_t openDuplicateOutput(audio_io_handle_t output1,
+                                    audio_io_handle_t output2) {
+        return 0;
+    }
+
+    virtual status_t closeOutput(audio_io_handle_t output) {
+        return NO_ERROR;
+    }
+
+    virtual status_t suspendOutput(audio_io_handle_t output) {
+        return NO_ERROR;
+    }
+
+    virtual status_t restoreOutput(audio_io_handle_t output) {
+        return NO_ERROR;
+    }
+
+    virtual status_t openInput(audio_module_handle_t module,
+                                        audio_devices_t *pDevices,
+                                        uint32_t *pSamplingRate,
+                                        audio_format_t *pFormat,
+                                        audio_channel_mask_t *pChannelMask) {
+        return NO_ERROR;
+    }
+
+    virtual status_t closeInput(audio_io_handle_t input) {
+        return NO_ERROR;
+    }
+
+    virtual status_t setStreamOutput(audio_stream_type_t stream, audio_io_handle_t output) {
+        return NO_ERROR;
+    }
+
+    virtual status_t setVoiceVolume(float volume) {
+        return NO_ERROR;
+    }
+
+    virtual status_t getRenderPosition(uint32_t *halFrames, uint32_t *dspFrames,
+                                    audio_io_handle_t output) const {
+        return NO_ERROR;
+    }
+
+    virtual uint32_t getInputFramesLost(audio_io_handle_t ioHandle) const {
+        return 0;
+    }
+
+    virtual int newAudioSessionId() {
+        return 0;
+    }
+
+    virtual void acquireAudioSessionId(int audioSession) {}
+    virtual void releaseAudioSessionId(int audioSession) {}
+
+    virtual status_t queryNumberEffects(uint32_t *numEffects) const {
+        *numEffects = 0;
+        return NO_ERROR;
+    }
+
+    virtual status_t queryEffect(uint32_t index, effect_descriptor_t *pDescriptor) const {
+        return NO_ERROR;
+    }
+
+    virtual status_t getEffectDescriptor(const effect_uuid_t *pEffectUUID,
+                                        effect_descriptor_t *pDescriptor) const {
+        return NO_ERROR;
+    }
+
+    virtual sp<IEffect> createEffect(
+                                    effect_descriptor_t *pDesc,
+                                    const sp<IEffectClient>& client,
+                                    int32_t priority,
+                                    audio_io_handle_t output,
+                                    int sessionId,
+                                    status_t *status,
+                                    int *id,
+                                    int *enabled) {
+        return 0;
+    }
+
+    virtual status_t moveEffects(int session, audio_io_handle_t srcOutput,
+                                    audio_io_handle_t dstOutput) {
+        return NO_ERROR;
+    }
+
+    virtual audio_module_handle_t loadHwModule(const char *name) {
+        return 0;
+    }
+
+    virtual uint32_t getPrimaryOutputSamplingRate() {
+        return 0;
+    }
+
+    virtual size_t getPrimaryOutputFrameCount() {
+        return 0;
+    }
+
+    virtual status_t setLowRamDevice(bool isLowRamDevice) {
+        return NO_ERROR;
+    }
+
+};
+
+sp<IPrivateAfGlue> MiniAudioFlinger::gPrivateAfGlue;

--- a/services/audioflinger_5_1_0.h
+++ b/services/audioflinger_5_1_0.h
@@ -176,6 +176,12 @@ public:
 
     virtual void registerClient(const sp<IAudioFlingerClient>& client) {}
 
+#ifdef QCOM_DIRECTTRACK
+    virtual status_t deregisterClient(const sp<IAudioFlingerClient>& client) {
+        return 0;
+    }
+#endif
+
     virtual size_t getInputBufferSize(uint32_t sampleRate, audio_format_t format,
             audio_channel_mask_t channelMask) const {
         return 0;

--- a/services/audioflinger_6_0_0.h
+++ b/services/audioflinger_6_0_0.h
@@ -1,0 +1,319 @@
+/*
+ * Copyright (C) 2015 Jolla Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Authored by: Juho Hämäläinen <juho.hamalainen@jollamobile.com>
+ */
+
+#include <media/IAudioFlingerClient.h>
+#include "IPrivateAfGlue.h"
+#include "common.h"
+
+using namespace android;
+
+class MiniAudioFlinger : public BinderService<MiniAudioFlinger>,
+                         public BnAudioFlinger,
+                         public IBinder::DeathRecipient
+{
+    friend class BinderService<MiniAudioFlinger>;
+
+    static sp<IPrivateAfGlue> gPrivateAfGlue;
+
+public:
+    static char const *getServiceName() {
+        return "media.audio_flinger";
+    }
+
+    MiniAudioFlinger() : BnAudioFlinger()
+    {
+        sp<IPrivateAfGlue> af;
+        sp<IServiceManager> sm = defaultServiceManager();
+        sp<IBinder> binder;
+
+        binder = sm->getService(String16(DROID_AFGLUE_SERVICE_NAME));
+        if (binder == 0) {
+            ALOGE("Couldn't find %s service", DROID_AFGLUE_SERVICE_NAME);
+        }
+        af = interface_cast<IPrivateAfGlue>(binder);
+
+        gPrivateAfGlue = af;
+    }
+
+    ~MiniAudioFlinger() {}
+
+    void binderDied(const wp<IBinder>&) {
+        // Nothing
+    }
+
+    virtual sp<IAudioTrack> createTrack(
+                                audio_stream_type_t streamType,
+                                uint32_t sampleRate,
+                                audio_format_t format,
+                                audio_channel_mask_t channelMask,
+                                size_t *pFrameCount,
+                                track_flags_t *flags,
+                                const sp<IMemory>& sharedBuffer,
+                                audio_io_handle_t output,
+                                pid_t tid,
+                                int *sessionId,
+                                int clientUid,
+                                status_t *status) {
+        return 0;
+    }
+
+    virtual sp<IAudioRecord> openRecord(
+                                audio_io_handle_t input,
+                                uint32_t sampleRate,
+                                audio_format_t format,
+                                audio_channel_mask_t channelMask,
+                                const String16& opPackageName,
+                                size_t *pFrameCount,
+                                track_flags_t *flags,
+                                pid_t tid,
+                                int clientUid,
+                                int *sessionId,
+                                size_t *notificationFrames,
+                                sp<IMemory>& cblk,
+                                sp<IMemory>& buffers,
+                                status_t *status) {
+        return 0;
+    }
+
+    virtual uint32_t sampleRate(audio_io_handle_t output) const {
+        return 0;
+    }
+
+    virtual audio_format_t format(audio_io_handle_t output) const {
+        return AUDIO_FORMAT_DEFAULT;
+    }
+
+    virtual size_t frameCount(audio_io_handle_t output) const {
+        return 0;
+    }
+
+    virtual uint32_t latency(audio_io_handle_t output) const {
+        return 0;
+    }
+
+    virtual status_t setMasterVolume(float value) {
+        return NO_ERROR;
+    }
+    virtual status_t setMasterMute(bool muted) {
+        return NO_ERROR;
+    }
+
+    virtual float masterVolume() const {
+        return 0;
+    }
+
+    virtual bool masterMute() const {
+        return false;
+    }
+
+    virtual     status_t    setStreamVolume(audio_stream_type_t stream, float value,
+                                    audio_io_handle_t output) {
+        return NO_ERROR;
+    }
+
+    virtual     status_t    setStreamMute(audio_stream_type_t stream, bool muted) {
+        return NO_ERROR;
+    }
+
+    virtual     float       streamVolume(audio_stream_type_t stream,
+                                    audio_io_handle_t output) const {
+        return 0;
+    }
+    virtual     bool        streamMute(audio_stream_type_t stream) const {
+        return false;
+    }
+
+    virtual     status_t    setMode(audio_mode_t mode) {
+        return NO_ERROR;
+    }
+
+    virtual     status_t    setMicMute(bool state) {
+        return NO_ERROR;
+    }
+
+    virtual     bool        getMicMute() const {
+        return false;
+    }
+
+    virtual     status_t    setParameters(audio_io_handle_t ioHandle,
+                                    const String8& keyValuePairs) {
+        return gPrivateAfGlue->setParameters(ioHandle, keyValuePairs);
+    }
+
+    virtual     String8     getParameters(audio_io_handle_t ioHandle, const String8& keys) const {
+        return gPrivateAfGlue->getParameters(ioHandle, keys);
+    }
+
+    virtual void registerClient(const sp<IAudioFlingerClient>& client) {}
+
+    virtual size_t getInputBufferSize(uint32_t sampleRate, audio_format_t format,
+            audio_channel_mask_t channelMask) const {
+        return 0;
+    }
+
+    virtual status_t openOutput(audio_module_handle_t module,
+                                audio_io_handle_t *output,
+                                audio_config_t *config,
+                                audio_devices_t *devices,
+                                const String8& address,
+                                uint32_t *latencyMs,
+                                audio_output_flags_t flags) {
+        return NO_ERROR;
+    }
+
+    virtual audio_io_handle_t openDuplicateOutput(audio_io_handle_t output1,
+                                    audio_io_handle_t output2) {
+        return 0;
+    }
+
+    virtual status_t closeOutput(audio_io_handle_t output) {
+        return NO_ERROR;
+    }
+
+    virtual status_t suspendOutput(audio_io_handle_t output) {
+        return NO_ERROR;
+    }
+
+    virtual status_t restoreOutput(audio_io_handle_t output) {
+        return NO_ERROR;
+    }
+
+    virtual status_t openInput(audio_module_handle_t module,
+                               audio_io_handle_t *input,
+                               audio_config_t *config,
+                               audio_devices_t *device,
+                               const String8& address,
+                               audio_source_t source,
+                               audio_input_flags_t flags) {
+        return NO_ERROR;
+    }
+
+    virtual status_t closeInput(audio_io_handle_t input) {
+        return NO_ERROR;
+    }
+
+    virtual status_t invalidateStream(audio_stream_type_t stream) {
+        return NO_ERROR;
+    }
+
+    virtual status_t setVoiceVolume(float volume) {
+        return NO_ERROR;
+    }
+
+    virtual status_t getRenderPosition(uint32_t *halFrames, uint32_t *dspFrames,
+                                    audio_io_handle_t output) const {
+        return NO_ERROR;
+    }
+
+    virtual uint32_t getInputFramesLost(audio_io_handle_t ioHandle) const {
+        return 0;
+    }
+
+    virtual audio_unique_id_t newAudioUniqueId() {
+        return 0;
+    }
+
+    virtual void acquireAudioSessionId(int audioSession, pid_t pid) {}
+    virtual void releaseAudioSessionId(int audioSession, pid_t pid) {}
+
+    virtual status_t queryNumberEffects(uint32_t *numEffects) const {
+        *numEffects = 0;
+        return NO_ERROR;
+    }
+
+    virtual status_t queryEffect(uint32_t index, effect_descriptor_t *pDescriptor) const {
+        return NO_ERROR;
+    }
+
+    virtual status_t getEffectDescriptor(const effect_uuid_t *pEffectUUID,
+                                        effect_descriptor_t *pDescriptor) const {
+        return NO_ERROR;
+    }
+
+    virtual sp<IEffect> createEffect(
+                                    effect_descriptor_t *pDesc,
+                                    const sp<IEffectClient>& client,
+                                    int32_t priority,
+                                    audio_io_handle_t output,
+                                    int sessionId,
+                                    const String16& opPackageName,
+                                    status_t *status,
+                                    int *id,
+                                    int *enabled) {
+        return 0;
+    }
+
+    virtual status_t moveEffects(int session, audio_io_handle_t srcOutput,
+                                    audio_io_handle_t dstOutput) {
+        return NO_ERROR;
+    }
+
+    virtual audio_module_handle_t loadHwModule(const char *name) {
+        return 0;
+    }
+
+    virtual uint32_t getPrimaryOutputSamplingRate() {
+        return 0;
+    }
+
+    virtual size_t getPrimaryOutputFrameCount() {
+        return 0;
+    }
+
+    virtual status_t setLowRamDevice(bool isLowRamDevice) {
+        return NO_ERROR;
+    }
+
+    virtual status_t listAudioPorts(unsigned int *num_ports,
+                                    struct audio_port *ports) {
+        return NO_ERROR;
+    }
+
+    virtual status_t getAudioPort(struct audio_port *port) {
+        return NO_ERROR;
+    }
+
+    virtual status_t createAudioPatch(const struct audio_patch *patch,
+                                       audio_patch_handle_t *handle) {
+        return NO_ERROR;
+    }
+
+    virtual status_t releaseAudioPatch(audio_patch_handle_t handle) {
+        return NO_ERROR;
+    }
+
+    virtual status_t listAudioPatches(unsigned int *num_patches,
+                                      struct audio_patch *patches) {
+        return NO_ERROR;
+    }
+
+    virtual status_t setAudioPortConfig(const struct audio_port_config *config) {
+        return NO_ERROR;
+    }
+
+    virtual audio_hw_sync_t getAudioHwSyncForSession(audio_session_t sessionId) {
+        return 0;
+    }
+
+    virtual status_t systemReady() {
+        return 0;
+    }
+
+};
+
+sp<IPrivateAfGlue> MiniAudioFlinger::gPrivateAfGlue;


### PR DESCRIPTION
A QCOM_DIRECTTRACK specific function was missing from the previous commit. Add also support for cm-11.0 and cm-13.0 based ports. Headers for cm-11.0 https://github.com/CyanogenMod/android_frameworks_av/blob/cm-11.0/services/audioflinger/AudioFlinger.h and cm-13.0 https://github.com/CyanogenMod/android_frameworks_av/blob/cm-13.0/services/audioflinger/AudioFlinger.h for reference.
