### PR TITLE
[audioflingerglue] fix/simplify obs build (and simplify local build).

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -1,7 +1,5 @@
 LOCAL_PATH:= $(call my-dir)
 
-USE_32BIT_MINIAF := $(shell cat $(LOCAL_PATH)/android-config.h |grep "\#define" |grep "USE_32BIT_MINIAF" |grep -o "true\|1")
-
 ANDROID_MAJOR :=
 ANDROID_MINOR :=
 ANDROID_MICRO :=
@@ -65,9 +63,6 @@ LOCAL_MODULE_TAGS := optional
 LOCAL_CPPFLAGS := -DANDROID_MAJOR=$(ANDROID_MAJOR) -DANDROID_MINOR=$(ANDROID_MINOR) -DANDROID_MICRO=$(ANDROID_MICRO)
 ifneq ($(CM_BUILD),)
 LOCAL_CPPFLAGS += -DCM_BUILD
-endif
-ifneq ($(strip $(USE_32BIT_MINIAF)),)
-LOCAL_MULTILIB := 32
 endif
 LOCAL_MODULE := miniafservice
 include $(BUILD_EXECUTABLE)

--- a/Android.mk
+++ b/Android.mk
@@ -64,5 +64,8 @@ LOCAL_CPPFLAGS := -DANDROID_MAJOR=$(ANDROID_MAJOR) -DANDROID_MINOR=$(ANDROID_MIN
 ifneq ($(CM_BUILD),)
 LOCAL_CPPFLAGS += -DCM_BUILD
 endif
+ifneq ($(shell cat frameworks/av/include/media/AudioSystem.h |grep GetEMParameter),)
+LOCAL_CPPFLAGS += -DUSE_SERVICES_VENDOR_EXTENSION
+endif
 LOCAL_MODULE := miniafservice
 include $(BUILD_EXECUTABLE)

--- a/android-config.h
+++ b/android-config.h
@@ -1,1 +1,0 @@
-/* Empty header for building outside OBS */

--- a/miniaf.cpp
+++ b/miniaf.cpp
@@ -25,7 +25,6 @@
 #include <binder/IPermissionController.h>
 #include <binder/MemoryHeapBase.h>
 #include "PrivateAfGlue.h"
-#include "android-config.h"
 
 #ifdef USE_SERVICES_VENDOR_EXTENSION
 

--- a/rpm/audioflingerglue.spec
+++ b/rpm/audioflingerglue.spec
@@ -15,7 +15,6 @@ License:       ASL 2.0
 BuildRequires: ubu-trusty
 BuildRequires: sudo-for-abuild
 BuildRequires: droid-bin-src-full
-BuildRequires: pkgconfig(android-headers)
 Source0:       %{name}-%{version}.tgz
 AutoReqProv:   no
 
@@ -45,8 +44,6 @@ mkdir -p external
 pushd external
 tar -zxf %SOURCE0
 mv audioflingerglue* audioflingerglue
-# Copy custom "android-config.h" for audioflinger build
-cp /usr/lib/droid-devel/droid-headers/android-config.h audioflingerglue
 popd
 
 %build


### PR DESCRIPTION
* build miniaf as 64 bit for now, until the underlying issue has been resolved (LD_LIBRARY_PATH - 32/64 bit mixup), so if BSP only supports 32 bit, it has to be solved there for now
* make the decision whether to use custom services headers independant
  of droid-hal-devel and local android-config.h