### PR TITLE
[32bit] simplify 32/64 bit builds. JB#41774

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -1,5 +1,7 @@
 LOCAL_PATH:= $(call my-dir)
 
+MINIAF_32 := $(shell cat frameworks/av/media/mediaserver/Android.mk |grep "LOCAL_32_BIT_ONLY[[:space:]]*:=[[:space:]]*" |grep -o "true\|1\|false\|0")
+
 ANDROID_MAJOR :=
 ANDROID_MINOR :=
 ANDROID_MICRO :=
@@ -68,4 +70,7 @@ ifneq ($(shell cat frameworks/av/include/media/AudioSystem.h |grep GetEMParamete
 LOCAL_CPPFLAGS += -DUSE_SERVICES_VENDOR_EXTENSION
 endif
 LOCAL_MODULE := miniafservice
+ifeq ($(strip $(MINIAF_32)), true)
+LOCAL_32_BIT_ONLY := true
+endif
 include $(BUILD_EXECUTABLE)


### PR DESCRIPTION
Decide whether to build 32 bit or 64 bit mini-services based on the
LOCAL_32_BIT_ONLY flag in frameworks/av/media/mediaserver/Android.mk.
Fixes from JB#41777 need to be merged before this one, then this needs
to be tested locally and on obs, to make sure nothing breaks.