### PR TITLE
Enable target autodetection for local builds too

### DIFF
--- a/detect_build_targets.sh
+++ b/detect_build_targets.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# default to building whatever target arch defines
+LIB_TARGET=
+
+if [ "$1" == "aarch64" ]; then
+    : # noop
+else
+    ANDROID_ARCH=`grep -h -m 1 "TARGET_ARCH *:=" device/*/*/*.mk | sed -e 's/ *TARGET_ARCH *:= *\([a-zA-Z0-9_]*\) */\1/'`
+    if [ "$ANDROID_ARCH" == "arm64" ]; then
+        LIB_TARGET=_32
+    fi
+fi
+
+echo libaudioflingerglue$LIB_TARGET miniafservice

--- a/rpm/audioflingerglue.spec
+++ b/rpm/audioflingerglue.spec
@@ -49,19 +49,7 @@ popd
 %build
 echo "building for %{device_rpm_architecture_string}"
 
-# default to building whatever target arch defines
-LIB_TARGET=libaudioflingerglue
-
-%if "%{device_rpm_architecture_string}" == "aarch64"
-    # noop
-%else
-    ANDROID_ARCH=`grep -h -m 1 "TARGET_ARCH *:=" device/*/*/*.mk | sed -e 's/ *TARGET_ARCH *:= *\([a-zA-Z0-9_]*\) */\1/'`
-    if [ "$ANDROID_ARCH" == "arm64" ]; then
-        LIB_TARGET=${LIB_TARGET}_32
-    fi
-%endif
-
-droid-make %{?_smp_mflags} $LIB_TARGET miniafservice
+droid-make %{?_smp_mflags} $(external/audioflingerglue/detect_build_targets.sh %{device_rpm_architecture_string})
 
 %install
 


### PR DESCRIPTION
Determine the arch of to-be-built libraries inside a script, so it can be used by both OBS and local builds.