### PR TITLE
[audioflinger] Add init file. JB#56158

### DIFF
--- a/init/miniaf.rc
+++ b/init/miniaf.rc
@@ -1,0 +1,4 @@
+service miniaf /usr/libexec/droid-hybris/system/bin/miniafservice
+    class main
+    user system
+    group audio


### PR DESCRIPTION
Add init file instead of patching servicemanager.rc in
hybris-patches to start miniaf